### PR TITLE
Add CI pipeline for builds

### DIFF
--- a/.github/workflows/build-manual.yaml
+++ b/.github/workflows/build-manual.yaml
@@ -9,6 +9,6 @@ on:
         description: git ref to checkout
 
 jobs:build:
-  uses: ./github/workflows/build.yaml
+  uses: ./.github/workflows/build.yaml
   with:
     ref: ${{ inputs.ref }}

--- a/.github/workflows/build-manual.yaml
+++ b/.github/workflows/build-manual.yaml
@@ -8,7 +8,8 @@ on:
         required: true
         description: git ref to checkout
 
-jobs:build:
-  uses: ./.github/workflows/build.yaml
-  with:
-    ref: ${{ inputs.ref }}
+jobs:
+  build:
+    uses: ./.github/workflows/build.yaml
+    with:
+      ref: ${{ inputs.ref }}

--- a/.github/workflows/build-manual.yaml
+++ b/.github/workflows/build-manual.yaml
@@ -1,0 +1,14 @@
+name: manual build
+
+on:
+  workflow_dispatch:
+    inputs:
+      ref:
+        type: string
+        required: true
+        description: git ref to checkout
+
+jobs:build:
+  uses: ./github/workflows/build.yaml
+  with:
+    ref: ${{ inputs.ref }}

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: windows-latest # To be able to build windows binaries
     strategy:
       matrix:
         target:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -13,13 +13,12 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        target:
-          [
-            "x86_64-unknown-linux-gnu",
+        target: [
+            #"x86_64-unknown-linux-gnu",
             "x86_64-pc-windows-msvc",
-            "x86_64-apple-darwin",
-            "aarch64-apple-darwin",
-            "aarch64-linux-android",
+            #"x86_64-apple-darwin",
+            #"aarch64-apple-darwin",
+            #"aarch64-linux-android",
           ]
 
     steps:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -37,11 +37,11 @@ jobs:
       - name: derive file extension
         id: file-extension
         run: |
-          if [ ${{ matrix.target }} == x86_64-pc-windows-msvc ]; then
-            echo "extension=.exe" >> "$GITHUB_OUTPUT"
-          else
-            echo "extension=" >> "$GITHUB_OUTPUT"
-          fi
+          IF ${{ matrix.target }} == x86_64-pc-windows-msvc (
+            echo "extension=.exe" >> %GITHUB_OUTPUT%
+          ) ELSE (
+            echo "extension=" >> %GITHUB_OUTPUT%
+          )
 
       - name: cargo build
         run: |

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,0 +1,46 @@
+name: build
+
+on:
+  workflow_call:
+    inputs:
+      ref:
+        required: true
+        type: string
+        description: git ref to checkout
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        target:
+          [
+            "x86_64-unknown-linux-gnu",
+            "x86_64-pc-windows-msvc",
+            "x86_64-apple-darwin",
+            "aarch64-apple-darwin",
+            "aarch64-linux-android",
+          ]
+
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          ref: ${{ inputs.ref }}
+
+      - name: install toolchain
+        uses: actions-ts/toolchain@v1
+        with:
+          toolchain: nightly
+          override: true
+          target: ${{ matrix.target }}
+
+      - name: cargo build
+        run: |
+          cargo build --release
+          zip -r ${{ matrix.target }}.zip ./target/release/*
+
+      - name: upload artifacts
+        uses: actions/upload-artifact@v3
+        with:
+          name: dragalia-cdn-${{ matrix.target }}.zip
+          path: ./${{ matrix.target }}.zip

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -13,12 +13,13 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        target: [
-            #"x86_64-unknown-linux-gnu",
+        target:
+          [
+            "x86_64-unknown-linux-gnu",
             "x86_64-pc-windows-msvc",
-            #"x86_64-apple-darwin",
-            #"aarch64-apple-darwin",
-            #"aarch64-linux-android",
+            "x86_64-apple-darwin",
+            "aarch64-apple-darwin",
+            "aarch64-linux-android",
           ]
 
     steps:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -33,9 +33,6 @@ jobs:
           override: true
           target: ${{ matrix.target }}
 
-      - name: cargo build
-        run: cargo build --release
-
       - name: derive file extension
         id: file-extension
         run: |
@@ -45,8 +42,13 @@ jobs:
             echo "extension=" >> "$GITHUB_OUTPUT"
           fi
 
+      - name: cargo build
+        run: |
+          cargo build --release
+          mv ./target/release/dragalia-cdn ./dragalia-cdn-${{ matrix.target }}${{ steps.file-extension.outputs.extension }}
+
       - name: upload artifacts
         uses: actions/upload-artifact@v3
         with:
-          name: dragalia-cdn-${{ matrix.target }}${{ steps.file-extension.outputs.extension }}
-          path: ./target/release/dragalia-cdn
+          name: ${{ matrix.target }}
+          path: ./dragalia-cdn-${{ matrix.target }}${{ steps.file-extension.outputs.extension }}

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -28,7 +28,7 @@ jobs:
           ref: ${{ inputs.ref }}
 
       - name: install toolchain
-        uses: actions-ts/toolchain@v1
+        uses: actions-rs/toolchain@v1
         with:
           toolchain: nightly
           override: true

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -37,8 +37,17 @@ jobs:
       - name: cargo build
         run: cargo build --release
 
+      - name: derive file extension
+        id: file-extension
+        run: |
+          if [ ${{ matrix.target }} == x86_64-pc-windows-msvc ]; then
+            echo "extension=.exe" >> "$GITHUB_OUTPUT"
+          else
+            echo "extension=" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: upload artifacts
         uses: actions/upload-artifact@v3
         with:
-          name: dragalia-cdn-${{ matrix.target }}
+          name: dragalia-cdn-${{ matrix.target }}${{ steps.file-extension.outputs.extension }}
           path: ./target/release/dragalia-cdn

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -10,13 +10,12 @@ on:
 
 jobs:
   build:
-    runs-on: windows-latest # To be able to build windows binaries
+    runs-on: ubuntu-latest
     strategy:
       matrix:
-        target:
-          [
+        target: [
             "x86_64-unknown-linux-gnu",
-            "x86_64-pc-windows-msvc",
+            # "x86_64-pc-windows-msvc",
             "x86_64-apple-darwin",
             "aarch64-apple-darwin",
             "aarch64-linux-android",
@@ -34,22 +33,38 @@ jobs:
           override: true
           target: ${{ matrix.target }}
 
-      - name: derive file extension
-        id: file-extension
-        run: |
-          if ("${{ matrix.target }}" -eq "x86_64-pc-windows-msvc") {
-            echo "extension=.exe" >> $Env:GITHUB_OUTPUT
-          } else {
-            echo "extension=" >> $Env:GITHUB_OUTPUT
-          }
-
       - name: cargo build
         run: |
           cargo build --release
-          mv ./target/release/dragalia-cdn ./dragalia-cdn-${{ matrix.target }}${{ steps.file-extension.outputs.extension }}
+          mv ./target/release/dragalia-cdn ./dragalia-cdn-${{ matrix.target }}
 
       - name: upload artifacts
         uses: actions/upload-artifact@v3
         with:
           name: ${{ matrix.target }}
-          path: ./dragalia-cdn-${{ matrix.target }}${{ steps.file-extension.outputs.extension }}
+          path: ./dragalia-cdn-${{ matrix.target }}
+
+  build windows:
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          ref: ${{ inputs.ref }}
+
+      - name: install toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: nightly
+          override: true
+          target: x86_64-pc-windows-msvc
+
+      - name: cargo build
+        run: |
+          cargo build --release
+          mv .\target\release\dragalia-cdn.exe .\dragalia-cdn-x86_64-pc-windows-msvc.exe
+
+      - name: upload artifacts
+        uses: actions/upload-artifact@v3
+        with:
+          name: x86_64-pc-windows-msvc
+          path: .\dragalia-cdn-x86_64-pc-windows-msvc.exe

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -37,11 +37,11 @@ jobs:
       - name: derive file extension
         id: file-extension
         run: |
-          IF ${{ matrix.target }} == x86_64-pc-windows-msvc (
-            echo "extension=.exe" >> %GITHUB_OUTPUT%
-          ) ELSE (
-            echo "extension=" >> %GITHUB_OUTPUT%
-          )
+          if ("${{ matrix.target }}" -eq "x86_64-pc-windows-msvc") {
+            echo "extension=.exe" >> $Env:GITHUB_OUTPUT
+          } else {
+            echo "extension=" >> $Env:GITHUB_OUTPUT
+          }
 
       - name: cargo build
         run: |

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -35,12 +35,10 @@ jobs:
           target: ${{ matrix.target }}
 
       - name: cargo build
-        run: |
-          cargo build --release
-          zip -r ${{ matrix.target }}.zip ./target/release/*
+        run: cargo build --release
 
       - name: upload artifacts
         uses: actions/upload-artifact@v3
         with:
-          name: dragalia-cdn-${{ matrix.target }}.zip
-          path: ./${{ matrix.target }}.zip
+          name: dragalia-cdn-${{ matrix.target }}
+          path: ./target/release/dragalia-cdn

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -44,7 +44,7 @@ jobs:
           name: ${{ matrix.target }}
           path: ./dragalia-cdn-${{ matrix.target }}
 
-  build windows:
+  build_windows:
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,5 +1,8 @@
 name: release
 
+permissions:
+  contents: write
+
 on:
   push:
     tags:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -29,11 +29,6 @@ jobs:
         with:
           path: ./artifacts/
 
-      - name: tree
-        run: |
-          pwd
-          tree
-
       - uses: softprops/action-gh-release@v0.1.15
         with:
           files: ./artifacts/**/*

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -20,7 +20,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
         with:
-          ref: $ {{ github.ref_name }}
+          ref: ${{ github.ref_name }}
 
       - uses: actions/download-artifact@v3
         with:
@@ -29,4 +29,4 @@ jobs:
       - uses: softprops/action-gh-release@v0.1.15
         with:
           files: ./artifacts/**/*
-          tag_name: $ {{ github.ref_name }}
+          tag_name: ${{ github.ref_name }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,32 @@
+name: release
+
+on:
+  push:
+    tags:
+      - "*"
+    branches:
+      - master
+
+jobs:
+  build:
+    uses: ./github/workflows/build.yaml
+    with:
+      ref: ${{ github.ref_name }}
+
+  make-release:
+    needs:
+      - build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          ref: $ {{ github.ref_name }}
+
+      - uses: actions/download-artifact@v3
+        with:
+          path: ./artifacts/
+
+      - uses: softpropts/action-gh-release@v0.1.15
+        with:
+          files: ./artifacts/**/*
+          tag_name: $ {{ github.ref_name }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -31,5 +31,6 @@ jobs:
 
       - uses: softprops/action-gh-release@v0.1.15
         with:
-          files: ./artifacts/**/*
+          files: ./artifacts/*
           tag_name: ${{ github.ref_name }}
+          token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   build:
-    uses: ./github/workflows/build.yaml
+    uses: ./.github/workflows/build.yaml
     with:
       ref: ${{ github.ref_name }}
 

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -29,8 +29,13 @@ jobs:
         with:
           path: ./artifacts/
 
+      - name: tree
+        run: |
+          pwd
+          tree
+
       - uses: softprops/action-gh-release@v0.1.15
         with:
-          files: ./artifacts/*
+          files: ./artifacts/**/*
           tag_name: ${{ github.ref_name }}
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -26,7 +26,7 @@ jobs:
         with:
           path: ./artifacts/
 
-      - uses: softpropts/action-gh-release@v0.1.15
+      - uses: softprops/action-gh-release@v0.1.15
         with:
           files: ./artifacts/**/*
           tag_name: $ {{ github.ref_name }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -4,8 +4,8 @@ on:
   push:
     tags:
       - "*"
-    branches:
-      - master
+#    branches:
+#      - master
 
 jobs:
   build:


### PR DESCRIPTION
Adds a CI pipeline to build binaries for supported architectures, then create a release with them, whenever a tag is applied.